### PR TITLE
[FIX]: Remove TS support for curried initialState on rereducer

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rereducer",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "license": "MIT",
   "repository": "github:josepot/rereducer",
   "bugs": "https://github.com/josepot/rereducer/issues",

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -23,7 +23,6 @@ export type RuleDef<TS, TA extends ActionWithType> =
   | ActionTypeRuleDef<TS, TA>
   | AdvancedRuleDef<TS, TA>;
 
-declare function rereducer<TS, TA extends ActionWithType>(...ruleDefs: Array<RuleDef<TS, TA>>): (initialValue: TS) => Reducer<TS, TA>;
 declare function rereducer<TS, TA extends ActionWithType>(initialValue: TS, ...ruleDefs: Array<RuleDef<TS, TA>>): Reducer<TS, TA>;
 
 export default rereducer;

--- a/types/rereducer.d.test.ts
+++ b/types/rereducer.d.test.ts
@@ -42,23 +42,6 @@ const myWatcher = (state: State, action: Action) => true;
   );
 });
 
-(() => { /// Curried initial value
-  // $ExpectType (initialValue: State) => Reducer<State, Action>
-  const noWatchers = rereducer<State, Action>(
-  );
-
-  // $ExpectType (initialValue: State) => Reducer<State, Action>
-  const singleWatcher = rereducer<State, Action>(
-    [ActionType.Action1, myAction1Reducer]
-  );
-
-  // $ExpectType (initialValue: State) => Reducer<State, Action>
-  const twoWatchers = rereducer<State, Action>(
-    [ActionType.Action1, myAction1Reducer],
-    [ActionType.Action2, myAction2Reducer]
-  );
-});
-
 (() => { /// Initial value as first parameter
   // $ExpectType Reducer<State, Action>
   const noWatchers = rereducer<State, Action>(
@@ -94,18 +77,5 @@ const myWatcher = (state: State, action: Action) => true;
     initialState,
     // $ExpectError
     [ActionType.Action1, myAction2Reducer]
-  );
-
-  rereducer<State, Action>(
-    [ActionType.Action2, myGenericReducer]
-  );
-
-  rereducer<State, Action>(
-    // $ExpectError
-    [ActionType.Action2, myAction1Reducer]
-  );
-
-  rereducer<State, Action>(
-    [ActionType.Action2, myAction2Reducer]
   );
 });


### PR DESCRIPTION
This feature is quite unused and will probably be deprecated on the next version - And it was causing TS to have a hard time figuring out which overload to use, specially when dealing with `null` initial values.